### PR TITLE
Added new Argon2 Erlang binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Bindings are available for the following languages (make sure to read
 their documentation):
 
 * [Elixir](https://github.com/riverrun/argon2_elixir) by [@riverrun](https://github.com/riverrun)
+* [Erlang](hhttps://github.com/ergenius/eargon2) by [@ergenius](https://github.com/ergenius)
 * [Go](https://github.com/tvdburgt/go-argon2) by [@tvdburgt](https://github.com/tvdburgt)
 * [Haskell](https://hackage.haskell.org/package/argon2-1.0.0/docs/Crypto-Argon2.html) by [@ocharles](https://github.com/ocharles)
 * [JavaScript (native)](https://github.com/ranisalt/node-argon2), by [@ranisalt](https://github.com/ranisalt)


### PR DESCRIPTION
A few days ago i started building an Argon2 Erlang binding called eArgon2. 

It's in his early beta stages, however it's working and bypassed simple tests. I added my binding to the binding list alphabetically (i noticed all are listed alphabetically). Please accept my listing. Thank's!